### PR TITLE
fix: disable landscape fullscreen mode

### DIFF
--- a/app/src/main/java/me/trion/whispertype/ime/WhisperKeyboardService.kt
+++ b/app/src/main/java/me/trion/whispertype/ime/WhisperKeyboardService.kt
@@ -75,6 +75,9 @@ class WhisperKeyboardService : InputMethodService() {
         }
         ViewCompat.requestApplyInsets(root)
     }
+
+    override fun onEvaluateFullscreenMode(): Boolean = false
+
     override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
         capturePrimaryClip()


### PR DESCRIPTION
`InputMethodService` turns on extract UI in landscape by default, so the IME window fills the screen with a gray text preview and a `Search` or `Done` button. `WhisperKeyboardService` never overrode `onEvaluateFullscreenMode()`. Returning `false` keeps the keyboard at the bottom.

```kotlin
override fun onEvaluateFullscreenMode(): Boolean = false
```

## Before
<img width="320" height="227" alt="image" src="https://github.com/user-attachments/assets/101e7f0e-d205-4c71-a7aa-d19a9c2808d8" />

## After
<img width="320" height="227" alt="image" src="https://github.com/user-attachments/assets/b1cd39a8-9349-47a2-aed1-2ddd10255402" />